### PR TITLE
[CU-26pmej6] Update node-executor to 17.9.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 executors:
   node-executor:
     docker:
-      - image: cimg/node:14.15.5
+      - image: cimg/node:17.9.0
 commands:
   verify-node-version:
     description: Check Node.js version used for the build


### PR DESCRIPTION
In the course of #3 , Node.js was updated locally to `17.9.0`. This PR is to update the `node-executor` on CircleCI reflect this change as well.