### PR TITLE
[CU-26pmcx5] Moves deploy-production to validation workflow with dependency on lint check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,9 +41,8 @@ workflows:
   validation:
     jobs:
       - lint_check
-  deploy-production-workflow:
-    jobs:
       - deploy-production:
           filters:
             branches:
               only: master
+          requires: lint_check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,4 +45,5 @@ workflows:
           filters:
             branches:
               only: master
-          requires: lint_check
+          requires:
+            - lint_check


### PR DESCRIPTION
## Background

The `deploy-production` workflow runs in parallel with the `validation` workflow, deploying the code regardless of if it passes validation. Instead, `deploy-production` should be dependent on `validation` passing.

## Changes
- Removes the separate `deploy-production` workflow and moves the `deploy-production` job into the `validation` workflow with a dependency on the `lint_check` job