### PR TITLE
[CU-2x1wkkd] Fix footer positioning on short pages

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -9,6 +9,7 @@ import ColorBar from './styles/ColorBar';
 const PageSections = styled.div`
   display: grid;
   grid-template-rows: auto 1fr auto;
+  min-height: 100vh;
 `;
 
 const Layout = ({ children }) => (


### PR DESCRIPTION
## Background
For shorter pages, the footer isn't at the bottom of the page because the page isn't tall enough making the page look a bit broken. This PR fixes that issue to ensure all pages are at least as tall as the viewport

**Before**:
![CU-2x1wkkd--before](https://user-images.githubusercontent.com/20213406/193319506-54d8f498-2f87-4ad8-aa2d-512a52388a9c.png)

**After**:
![CU-2x1wkkd--after](https://user-images.githubusercontent.com/20213406/193319547-ac6298f4-7ac8-4c70-87bf-f0aa9dd93e65.png)

## Updates
- Added `min-height` property to `PageSections` component to ensure all pages will at least be as tall as the viewport

## How to test
- Go to the [Contact page](https://yujinelson.com/contact) and make sure the footer is a the bottom of the viewport instead of part-way up.