### PR TITLE
[CU-31wc9hq] Moves CurrentYear to separate directory

### DIFF
--- a/src/components/CurrentYear.tsx
+++ b/src/components/CurrentYear.tsx
@@ -1,6 +1,0 @@
-import * as React from 'react';
-import { format } from 'date-fns';
-
-const CurrentYear: React.FC = () => <span>{format(new Date(), 'yyyy')}</span>;
-
-export default CurrentYear;

--- a/src/components/CurrentYear/CurrentYear.tsx
+++ b/src/components/CurrentYear/CurrentYear.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import { format } from 'date-fns';
+
+export const CurrentYear: React.FC = () => (
+  <span>{format(new Date(), 'yyyy')}</span>
+);

--- a/src/components/CurrentYear/index.ts
+++ b/src/components/CurrentYear/index.ts
@@ -1,2 +1,1 @@
-export * from './ContactCard';
 export * from './CurrentYear';

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { colors, fonts, mq, spacing } from './styles/theme';
 import Container from './styles/Container';
-import CurrentYear from './CurrentYear';
+import { CurrentYear } from './CurrentYear';
 import SocialMediaIcons from './SocialMediaIcons';
 import Logo from './Logo';
 import ResumeLink from './ResumeLink';


### PR DESCRIPTION
## Background
This is a part of an effort to migrate the codebase to TypeScript. While the `CurrentYear` had already been migrated to TS in a [previous PR](https://github.com/justaddcl/yujinelson.com/pull/74), this PR reorganises the component into its own components sub-directory to be consistent with the other changes.

## Changes
- Moves `CurrentYear` to its own components sub-directory

## How to test
Ensure the `CurrentYear` component renders as expected in the `Footer` component