### PR TITLE
[YUJI-21] Add experience impact summaries

### DIFF
--- a/src/components/ExperienceCard.js
+++ b/src/components/ExperienceCard.js
@@ -90,6 +90,16 @@ const StyledExperienceCard = styled.div`
     }
   }
 
+  .role-impact-summary {
+    color: ${colors.grey[200]};
+    line-height: 1.5;
+    margin: ${spacing.s}rem 0 0;
+
+    @media screen and (min-width: ${mq.desktop.small}) {
+      grid-column: 1 / 3;
+    }
+  }
+
   .role-bullets {
     list-style-type: disc;
     margin-top: ${spacing.s}rem;
@@ -180,6 +190,7 @@ const ExperienceCard = ({
   logo,
   location,
   roles,
+  summary,
   tags,
   children,
 }) => (
@@ -200,6 +211,7 @@ const ExperienceCard = ({
           {team && <span className="role-team">/ {team}</span>}
         </div>
       </div>
+      {summary && <p className="role-impact-summary">{summary}</p>}
       <div className="experience-tags">
         {tags && tags.map((tag) => <ExperienceTag tag={tag} key={tag} />)}
       </div>

--- a/src/components/ExperienceCard.js
+++ b/src/components/ExperienceCard.js
@@ -97,6 +97,7 @@ const StyledExperienceCard = styled.div`
 
     @media screen and (min-width: ${mq.desktop.small}) {
       grid-column: 1 / 3;
+      grid-row: 2;
     }
   }
 

--- a/src/components/ExperienceCard.js
+++ b/src/components/ExperienceCard.js
@@ -14,9 +14,9 @@ const StyledExperienceCard = styled.div`
   --inner-role-primary-size: 1rem;
 
   display: grid;
-  grid-template: auto / var(--role-left-column) 1fr;
+  grid-template-columns: var(--role-left-column) 1fr;
   column-gap: var(--role-column-gap);
-  row-gap: ${spacing.s}rem;
+  row-gap: ${spacing.m}rem;
   font-family: ${fonts.family.sourceCodePro};
   margin-bottom: ${spacing.base}rem;
   padding-top: ${spacing.base}rem;
@@ -31,6 +31,7 @@ const StyledExperienceCard = styled.div`
 
   @media screen and (min-width: ${mq.desktop.small}) {
     --role-column-gap: ${spacing.m}rem;
+    row-gap: ${spacing.xs}rem;
   }
 
   .company-logo {
@@ -93,11 +94,15 @@ const StyledExperienceCard = styled.div`
   .role-impact-summary {
     color: ${colors.grey[200]};
     line-height: 1.5;
-    margin: ${spacing.s}rem 0 0;
+    margin-bottom: ${spacing.base}rem;
+    grid-column: 1 / -1;
+
+    &:not(:last-child) {
+      margin-bottom: ${spacing.s}rem;
+    }
 
     @media screen and (min-width: ${mq.desktop.small}) {
-      grid-column: 1 / 3;
-      grid-row: 2;
+      margin-bottom: 0;
     }
   }
 
@@ -212,12 +217,12 @@ const ExperienceCard = ({
           {team && <span className="role-team">/ {team}</span>}
         </div>
       </div>
-      {summary && <p className="role-impact-summary">{summary}</p>}
       <div className="experience-tags">
         {tags && tags.map((tag) => <ExperienceTag tag={tag} key={tag} />)}
       </div>
       {children}
     </div>
+    {summary && <p className="role-impact-summary">{summary}</p>}
     {roles && (
       <>
         {roles.map((innerRole) => (

--- a/src/data/experience.ts
+++ b/src/data/experience.ts
@@ -14,7 +14,7 @@ export type Experience = {
   role: string;
   location: string;
   dates: DateRange;
-  summary: string | null;
+  summary: string;
   classification?: string;
   logo: string;
   team?: string;
@@ -34,7 +34,8 @@ const experience: Experience[] = [
       start: '11/2021',
       end: '09/2022',
     },
-    summary: null,
+    summary:
+      "Built customer-facing features for Duffel's travel platform, including search, checkout, and product discovery experiences.",
     classification: 'software-engineering',
     logo: 'duffelLogo',
     team: 'UX Products',
@@ -54,7 +55,8 @@ const experience: Experience[] = [
       start: '09/2017',
       end: '05/2021',
     },
-    summary: null,
+    summary:
+      "Led front-end development and UX delivery for Magpul's B2B and B2C ecommerce websites.",
     classification: 'software-engineering',
     logo: 'magpulLogo',
     team: 'Marketing',
@@ -76,7 +78,8 @@ const experience: Experience[] = [
       start: '07/2014',
       end: '06/2017',
     },
-    summary: null,
+    summary:
+      'Completed a three-year IT career foundation programme, rotating through communications and PC hardware web development teams.',
     classification: 'software-engineering',
     logo: 'boeingLogo',
     companyFirst: true,

--- a/src/data/experience.ts
+++ b/src/data/experience.ts
@@ -35,7 +35,7 @@ const experience: Experience[] = [
       end: '09/2022',
     },
     summary:
-      "Built customer-facing features for Duffel's travel platform, including search, checkout, and product discovery experiences.",
+      "Built a TypeScript and Meilisearch search experience to help customers quickly find orders, alongside loyalty checkout and product-discovery features in Duffel's Next.js app.",
     classification: 'software-engineering',
     logo: 'duffelLogo',
     team: 'UX Products',

--- a/src/data/experience.ts
+++ b/src/data/experience.ts
@@ -98,7 +98,7 @@ const experience: Experience[] = [
       },
       {
         title: 'Web Developer',
-        team: 'Enterprise Communications',
+        team: 'Enterprise Mobility',
         start: '07/2014',
         end: '06/2015',
       },

--- a/src/data/experience.ts
+++ b/src/data/experience.ts
@@ -79,7 +79,7 @@ const experience: Experience[] = [
       end: '06/2017',
     },
     summary:
-      'Completed a three-year IT career foundation programme, rotating through communications and PC hardware web development teams.',
+      'Delivered and redesigned critical, enterprise-wide internal websites across all three rotations, combining web strategy, user research, and front-end development.',
     classification: 'software-engineering',
     logo: 'boeingLogo',
     companyFirst: true,

--- a/src/data/experience.ts
+++ b/src/data/experience.ts
@@ -35,7 +35,7 @@ const experience: Experience[] = [
       end: '09/2022',
     },
     summary:
-      "Built a TypeScript and Meilisearch search experience to help customers quickly find orders, alongside loyalty checkout and product-discovery features in Duffel's Next.js app.",
+      "Delivered customer-facing discovery, search, and loyalty experiences for Duffel's Next.js app, including Meilisearch-powered order search, a multi-step checkout flow, and a feed-style homepage for product education.",
     classification: 'software-engineering',
     logo: 'duffelLogo',
     team: 'UX Products',

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -116,6 +116,7 @@ const About = ({ data }) => (
         logo={data.duffelLogo}
         role={duffelExperience.role}
         roles={duffelExperience.roles}
+        summary={duffelExperience.summary}
         tags={duffelExperience.tags}
         team={duffelExperience.team}
       >

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -67,6 +67,7 @@ const Home = ({ data }) => (
           logo={data[entry.logo]}
           role={entry.role}
           roles={entry.roles}
+          summary={entry.summary}
           tags={entry.tags}
           team={entry.team}
         />


### PR DESCRIPTION
## Background

The published experience cards list the role, company, dates and tags, but do not explain the scope of each role at a glance.

https://linear.app/paranoid-android/issue/YUJI-21/add-impact-summaries-to-experience-cards

## What's changed

- Add a required concise summary to every currently published experience entry.
- Render summaries in experience cards on the home and About pages.
- Keep summaries responsive: single-column on mobile and alongside the existing card metadata on desktop.

## How to test

- `npm run check-types`
- `npm run lint`
- `npm run prettier-check`
- `npm run build`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds concise impact summaries to published experience data and renders them on the home and About pages.
- Makes summaries required in the experience data type and supplies content for every published entry.
- Passes summaries into each experience card.
- Places summaries in a separate responsive grid row so existing desktop metadata retains its layout.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/ExperienceCard.js | Adds summary rendering and moves it outside the metadata sub-grid, resolving the previously reported desktop auto-placement conflicts. |
| src/data/experience.ts | Makes experience summaries required and supplies summary text for every published role. |
| src/pages/about.js | Passes the latest role's summary into the About-page experience card. |
| src/pages/index.js | Passes each experience summary into the corresponding home-page card. |

<sub>Reviews (9): Last reviewed commit: ["Fix Boeing team name"](https://github.com/justaddcl/yujinelson.com/commit/4c038a5611cf28a4c7feb0fb411ce5ad0196dfd0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53389060)</sub>

<!-- /greptile_comment -->