### PR TITLE
[YUJI-XXX] Route PostHog through the managed proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is the codebase for my [personal website](https://yujinelson.com) built wit
 
 ## Analytics
 
-PostHog is enabled when `GATSBY_POSTHOG_KEY` and `GATSBY_POSTHOG_HOST` are set. Visitors are opted out until they make an explicit choice in the analytics consent banner.
+PostHog is enabled when `GATSBY_POSTHOG_KEY` and `GATSBY_POSTHOG_HOST` are set. Set `GATSBY_POSTHOG_HOST` to the managed proxy URL (`https://wa.yujinelson.com`) in each environment; visitors are opted out until they make an explicit choice in the analytics consent banner.
 
 PostHog automatically captures standard UTM parameters. Use an opaque `application_ref` to associate a visit with a job application without putting a company or person in the URL:
 

--- a/src/analytics/posthog.ts
+++ b/src/analytics/posthog.ts
@@ -3,6 +3,7 @@ import posthog from 'posthog-js';
 
 const posthogKey = process.env.GATSBY_POSTHOG_KEY;
 const posthogHost = process.env.GATSBY_POSTHOG_HOST;
+const posthogUiHost = 'https://eu.posthog.com';
 
 const analyticsConsentSettingsEvent = 'analytics-consent-settings';
 
@@ -35,6 +36,7 @@ export const initializeAnalytics = () => {
 
   posthog.init(posthogKey, {
     api_host: posthogHost,
+    ui_host: posthogUiHost,
     defaults: '2026-05-30',
     capture_pageview: 'history_change',
     custom_campaign_params: ['application_ref'],

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -73,7 +73,8 @@ const Privacy = () => (
       <Text textStyle="paragraph">
         I use this information to understand how people find and use the site,
         and to improve its content and usability. The processing is based on
-        your consent. PostHog processes the data on my behalf. You can read{' '}
+        your consent. PostHog and its managed proxy process the data on my
+        behalf. You can read{' '}
         <a href="https://posthog.com/privacy">PostHog&apos;s privacy notice</a>.
         Analytics data is reviewed periodically and deleted when it is no longer
         useful.

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -49,8 +49,7 @@ const Privacy = () => (
     <section>
       <H2>What is collected</H2>
       <Text textStyle="paragraph">
-        If you accept, PostHog records usage information that is not linked to
-        your name or email address, including:
+        If you accept, PostHog records usage information, including:
       </Text>
       <ul>
         <li>pages viewed and links or buttons clicked;</li>
@@ -63,9 +62,10 @@ const Privacy = () => (
       <H2>How it is protected</H2>
       <Text textStyle="paragraph">
         Form inputs are masked in session replays, console logs are not
-        recorded, and this site does not attach your name or email address to
-        analytics events. Please avoid putting personal information in campaign
-        parameters when sharing a link to this site.
+        recorded, and this site does not send your name or email address to
+        PostHog. An application_ref can associate a visit with a job application
+        in a private tracker, so please avoid putting personal information in
+        campaign parameters when sharing a link to this site.
       </Text>
     </section>
     <section>


### PR DESCRIPTION
## Background

The managed PostHog proxy at `wa.yujinelson.com` is configured and healthy. The site should continue to take its ingestion host from `GATSBY_POSTHOG_HOST`, so each deployment environment can explicitly select the proxy.

## What's changed

Keeps `GATSBY_POSTHOG_HOST` as the browser analytics API host, documents setting it to `https://wa.yujinelson.com`, and adds PostHog's EU UI host required for proxied API traffic. Updates the privacy copy to reflect the managed proxy.

## How to test

- Set `GATSBY_POSTHOG_HOST=https://wa.yujinelson.com`
- `npm run prettier-check`
- `npm run check-types`
- `npm run lint` (58 existing warnings; no errors)
- `npm run build`
- `curl -I https://wa.yujinelson.com/decide/?v=3` returns `200`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Updated analytics integration to use the EU-based PostHog interface.
  * Analytics data continues to follow the existing consent behavior.

* **Documentation**
  * Clarified the required PostHog proxy URL for each environment.
  * Updated the Privacy page to explain that PostHog and its managed proxy process analytics data on the site owner’s behalf.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR routes PostHog API traffic through the environment-configured managed proxy while setting the corresponding EU PostHog UI host.
- Documents `https://wa.yujinelson.com` as the required analytics proxy.
- Adds `https://eu.posthog.com` as PostHog’s UI host.
- Updates the privacy notice to describe proxy processing and application-reference tracking.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| README.md | Documents the managed proxy value expected for `GATSBY_POSTHOG_HOST`. |
| src/analytics/posthog.ts | Adds PostHog’s EU UI host while preserving the environment-configured API host and existing consent behavior. |
| src/pages/privacy.tsx | Updates analytics disclosures to cover managed-proxy processing and opaque application references. |

<sub>Reviews (3): Last reviewed commit: ["\[YUJI-XXX\] Clarify analytics privacy dis..."](https://github.com/justaddcl/yujinelson.com/commit/4d1ec64edd0a66069aabb427cb39356c47b5750d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55829610)</sub>

<!-- /greptile_comment -->