### PR TITLE
[YUJI-XXX] Keep CV aliases current

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
       - setup
       - run: npm run lint
       - run: npm run prettier-check
+      - run: npm run check-cv
   deploy-production:
     executor: node-executor
     steps:
@@ -44,6 +45,9 @@ jobs:
           arguments: |
             --acl public-read \
             --cache-control "max-age=86400" \
+      - run:
+          name: Publish stable CV aliases
+          command: node scripts/publish-cv-aliases.js
 workflows:
   version: 2
   validation:

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Add each new CV to `static/` as `Yuji-Nelson-CV-YYYY.pdf`. The highest versioned
 filename is treated as current; `npm run check-cv` verifies that one exists.
 On every `master` deployment, CircleCI uploads it, then makes `/cv` and `/resume`
 S3 website redirects to that filename with no-cache headers and invalidates their
-CloudFront cache entries. This requires the non-secret CircleCI variable
-`CLOUDFRONT_DISTRIBUTION_ID`.
+CloudFront cache entries. This requires the non-secret CircleCI variables
+`S3_BUCKET_NAME` and `CLOUDFRONT_DISTRIBUTION_ID`.
 
 ## Analytics
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@
 ![Screenshot of yujinelson.com](static/yujinelson.com.png)
 This is the codebase for my [personal website](https://yujinelson.com) built with Gatsby and hosted on AWS.
 
+## CV
+
+Add each new CV to `static/` as `Yuji-Nelson-CV-YYYY.pdf`. The highest versioned
+filename is treated as current; `npm run check-cv` verifies that one exists.
+On every `master` deployment, CircleCI uploads it, then makes `/cv` and `/resume`
+S3 website redirects to that filename with no-cache headers and invalidates their
+CloudFront cache entries. This requires the non-secret CircleCI variable
+`CLOUDFRONT_DISTRIBUTION_ID`.
+
 ## Analytics
 
 PostHog is enabled when `GATSBY_POSTHOG_KEY` and `GATSBY_POSTHOG_HOST` are set. Set `GATSBY_POSTHOG_HOST` to the managed proxy URL (`https://wa.yujinelson.com`) in each environment; visitors are opted out until they make an explicit choice in the analytics consent banner.

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -1,6 +1,8 @@
+import { join } from 'node:path';
 import type { GatsbyNode } from 'gatsby';
+import { findLatestCvFilename } from './scripts/find-latest-cv';
 
-const cv = '/Yuji-Nelson-CV-2026.pdf';
+const cv = `/${findLatestCvFilename(join(process.cwd(), 'static'))}`;
 const cvAliasUrls = ['/resume', '/cv'];
 
 /**

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "gatsby build",
+    "check-cv": "node scripts/find-latest-cv.js static",
     "check-types": "tsc --noEmit --project tsconfig.json",
     "dev": "env-cmd -f .env.development gatsby develop",
     "dev-m": "env-cmd -f .env.development gatsby develop -H 192.168.1.93 -p 8000",

--- a/scripts/find-latest-cv.js
+++ b/scripts/find-latest-cv.js
@@ -1,0 +1,32 @@
+const { readdirSync } = require('node:fs');
+const { join } = require('node:path');
+
+const CV_FILENAME_PATTERN = /^Yuji-Nelson-CV-(\d{4})\.pdf$/;
+
+function findLatestCvFilename(directory) {
+  const cvFiles = readdirSync(directory)
+    .filter((filename) => CV_FILENAME_PATTERN.test(filename))
+    .sort();
+
+  if (cvFiles.length === 0) {
+    throw new Error(
+      `No versioned CV found in ${directory}. Add a file named Yuji-Nelson-CV-YYYY.pdf.`
+    );
+  }
+
+  return cvFiles[cvFiles.length - 1];
+}
+
+if (require.main === module) {
+  const directory = process.argv[2];
+
+  if (!directory) {
+    throw new Error('Usage: node scripts/find-latest-cv.js <directory>');
+  }
+
+  process.stdout.write(
+    `${findLatestCvFilename(join(process.cwd(), directory))}\n`
+  );
+}
+
+module.exports = { findLatestCvFilename };

--- a/scripts/publish-cv-aliases.js
+++ b/scripts/publish-cv-aliases.js
@@ -1,0 +1,58 @@
+const { execFileSync } = require('node:child_process');
+const { join } = require('node:path');
+const { findLatestCvFilename } = require('./find-latest-cv');
+
+const aliases = ['cv', 'resume'];
+const isDryRun = process.argv.includes('--dry-run');
+const bucket = process.env.S3_BUCKET_NAME;
+const distributionId = process.env.CLOUDFRONT_DISTRIBUTION_ID;
+const cvFilename = findLatestCvFilename(join(process.cwd(), 'public'));
+const redirectTarget = `/${cvFilename}`;
+
+function requireEnvironmentVariable(name, value) {
+  if (!value) {
+    throw new Error(`${name} must be set before publishing CV aliases.`);
+  }
+}
+
+function runAws(arguments_) {
+  if (isDryRun) {
+    process.stdout.write(`aws ${arguments_.join(' ')}\n`);
+    return '';
+  }
+
+  return execFileSync('aws', arguments_, { encoding: 'utf8' });
+}
+
+requireEnvironmentVariable('S3_BUCKET_NAME', bucket);
+requireEnvironmentVariable('CLOUDFRONT_DISTRIBUTION_ID', distributionId);
+
+aliases.forEach((alias) => {
+  runAws([
+    's3api',
+    'put-object',
+    '--bucket',
+    bucket,
+    '--key',
+    alias,
+    '--website-redirect-location',
+    redirectTarget,
+    '--content-type',
+    'text/html',
+    '--cache-control',
+    'max-age=0, no-cache',
+  ]);
+});
+
+runAws([
+  'cloudfront',
+  'create-invalidation',
+  '--distribution-id',
+  distributionId,
+  '--paths',
+  ...aliases.map((alias) => `/${alias}`),
+]);
+
+process.stdout.write(
+  `Published /cv and /resume as no-cache redirects to ${redirectTarget}.\n`
+);


### PR DESCRIPTION
The production CV aliases drifted because Gatsby redirects are not S3 website redirects. A new versioned CV could therefore leave /cv and /resume pointing to an old file.\n\nThis makes deployment own the aliases: it detects the latest versioned CV, writes no-cache S3 redirect objects for /cv and /resume, and invalidates only those CloudFront paths. CI also verifies that a correctly named CV exists.\n\nNo UI/UX changes. If CI passes, that should be sufficient to verify these changes.\n\n@coderabbitai summary



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The deployment now owns the stable CV aliases and CI verifies that a versioned CV exists.
- Selects the highest versioned CV filename for Gatsby redirects and deployment aliases.
- Publishes no-cache S3 redirect objects for `/cv` and `/resume`.
- Invalidates only the corresponding CloudFront paths.
- Documents both required CircleCI environment variables.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .circleci/config.yml | Adds CV validation and publishes stable aliases after the production site upload. |
| README.md | Documents the CV naming convention and both required CircleCI variables, resolving the previous finding. |
| gatsby-node.ts | Replaces the hardcoded CV filename with dynamically selected latest-version behavior. |
| scripts/find-latest-cv.js | Selects the highest matching four-digit CV version and fails when none exists. |
| scripts/publish-cv-aliases.js | Writes S3 redirect objects and invalidates the matching CloudFront alias paths. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant CI as CircleCI
  participant Gatsby
  participant S3
  participant CF as CloudFront
  CI->>CI: Verify versioned CV exists
  CI->>Gatsby: Build site
  Gatsby-->>CI: public/ with latest CV
  CI->>S3: Sync public/
  CI->>S3: Write /cv and /resume redirects
  CI->>CF: Invalidate /cv and /resume
```

<sub>Reviews (2): Last reviewed commit: ["Document CV deployment variables"](https://github.com/justaddcl/yujinelson.com/commit/c7673f7e0970ef197df64224cc86cd39841eea34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55837319)</sub>

<!-- /greptile_comment -->